### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,11 @@
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 ![Last Commit](https://img.shields.io/github/last-commit/DanielAvdar/dev-kit-mcp-server/main)
 
-A Model Context Protocol (MCP) server targeted for agent development tools, providing scoped authorized operations in the root project directory.
-This package enables secure execution of operations such as running makefile commands, moving and deleting files, with future plans to include more tools for code editing.
-It serves as an excellent MCP server for VS-Code copilot and other AI-assisted development tools.
+A Model Context Protocol (MCP) server targeted for agent development tools, providing scoped authorized operations in the root project directory. This package enables secure execution of operations such as running makefile commands, moving and deleting files, with future plans to include more tools for code editing. It serves as an excellent MCP server for VS-Code copilot and other AI-assisted development tools.
+
+<a href="https://glama.ai/mcp/servers/@DanielAvdar/dev-kit-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@DanielAvdar/dev-kit-mcp-server/badge" alt="dev-kit-mcp-server MCP server" />
+</a>
 
 ## Features
 


### PR DESCRIPTION
This PR adds a badge for the [dev-kit-mcp-server](https://glama.ai/mcp/servers/@DanielAvdar/dev-kit-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@DanielAvdar/dev-kit-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@DanielAvdar/dev-kit-mcp-server/badge" alt="dev-kit-mcp-server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.